### PR TITLE
Fix a bug about If-Modified-Since header

### DIFF
--- a/misc/plugin/rss.rb
+++ b/misc/plugin/rss.rb
@@ -94,7 +94,7 @@ def rss
     if_modified_since = nil
   end
 
-  if if_modified_since and last_modified < if_modified_since
+  if if_modified_since and last_modified <= if_modified_since
     header['status'] = 'NOT_MODIFIED'
     return ::Hiki::Response.new('', 304, header)
   else

--- a/test/test_plugin_rss.rb
+++ b/test/test_plugin_rss.rb
@@ -1,0 +1,48 @@
+# To do: Handle Exception raised in Time.parse line 92
+
+require 'test/unit'
+require 'time'
+require 'cgi'
+require 'rack'
+require File.join(File.dirname(__FILE__), *%w[.. hiki request])
+require File.join(File.dirname(__FILE__), *%w[.. hiki response])
+
+class Plugin_RSS_Unit_Tests < Test::Unit::TestCase
+  def setup
+    @now = Time.parse(CGI.rfc1123_date(Time.now))
+    @request = Object.new
+    class << @request
+      def params; {}; end
+    end
+    @conf = Object.new
+    class << @conf
+      def charset; end
+      def lang; end
+    end
+    plugin_file = File.expand_path(File.join(File.dirname(__FILE__), *%w{.. misc plugin rss.rb}))
+    instance_eval(File.read(plugin_file))
+    class << self
+      define_method(:rss_body) {|*page_num| ['', @now]}
+    end
+  end
+
+  def test_rss_returns_304_when_if_modified_since_is_same_to_last_modified
+    ENV['HTTP_IF_MODIFIED_SINCE'] = CGI.rfc1123_date(@now)
+    assert_equal 304, rss.status
+  end
+
+  def add_body_enter_proc(prcedure)
+  end
+
+  def add_header_proc(procedure)
+  end
+
+  def add_conf_proc(plugin_name, procedure)
+  end
+
+  def export_plugin_methods(*args)
+  end
+
+  def label_rss_config
+  end
+end


### PR DESCRIPTION
初めまして。

暫く前に公式サイトの[ITS](http://hikiwiki.org/its/)も書いたのですが、
テストを書いたので改めてご連絡します。

RSSプラグインのIf-Modified-Sinceヘッダーの扱いがおかしくて
Hikiの最終更新時刻とIf-Modified-Sinceが等しい時にも
200としてレスポンスボディを返してしまっていました。

パッチ（と言っても一文字ですが）をご検討ください。

プラグインのテストについて約束が無いようだったので
その場凌ぎ的に書いてしまいましたが、
方針が決まっているようでしたら書き直します。
