### PR TITLE
Add current directory to $LOAD_PATH for Ruby 1.9

### DIFF
--- a/hiki.ru
+++ b/hiki.ru
@@ -1,5 +1,6 @@
 #!/usr/bin/env rackup
 # -*- ruby -*-
+$LOAD_PATH << File.dirname(__FILE__)
 require 'hiki/app'
 require 'hiki/attachment'
 


### PR DESCRIPTION
こんにちは、北市真です。

Ruby 1.9から、実行時にカレントディレクトリーがロードパスに含まれなくなったため、

```
rackup hiki.ru
```

がエラーになってしまいます。
修正を送りますのでご検討ください。
