### PR TITLE
Fix converter error

### DIFF
--- a/tool/convert.rb
+++ b/tool/convert.rb
@@ -48,7 +48,7 @@ def main(argv)
   end
 
   require_relative "../hiki/repos/#{repository_type}"
-  repository_class = ::Hiki.const_get("Repos#{repository_type}")
+  repository_class = ::Hiki.const_get("Repos#{repository_type.capitalize}")
 
   convert(data_dir, repository_class, input_encoding, output_encoding)
 end


### PR DESCRIPTION
tool/convert.rb を使ってみたところ、動かない箇所があったので直しました。

なお、この状態で

```
$ ruby tool/convert.rb -d data -i EUC-JP -o UTF-8
```

と実行すると、

```
hiki/hiki/repos/plain.rb:70:in `read': No such file or directory - data/text/.wiki (Errno::ENOENT)
```

とエラーになってしまいます。.wiki を新規作成して、その中に従来のデータを入れれば良いのでしょうか?
