### PR TITLE
Fixed the third argument fname of ERB#def_method

### DIFF
--- a/hiki/page.rb
+++ b/hiki/page.rb
@@ -42,7 +42,7 @@ module Hiki
       end
       unless respond_to?(content_method_name)
         erb = ERB.new(@template)
-        erb.def_method(self.class, content_method_name, layout_name)
+        erb.def_method(self.class, content_method_name, content_name)
       end
       __send__(layout_method_name){ __send__(content_method_name) }
     end


### PR DESCRIPTION
テンプレート内で例外が起きた場合 エラーの仮称が layout.html と表示されてしまっていましたので、修正してみました。

下記のコミットにて混入したバグだと思います。

05a68cce9780c86cfc1be7dce68dfaebcc90b6fa
