### PR TITLE
Remove trailing slash of @data_path

### DIFF
--- a/hiki/config.rb
+++ b/hiki/config.rb
@@ -138,7 +138,6 @@ module Hiki
       formaterror if $data_path
 
       raise 'No @data_path variable.' unless @data_path
-      @data_path += '/' if /\/$/ !~ @data_path
 
       # default values
       @smtp_server   ||= 'localhost'


### PR DESCRIPTION
It generate double slashed paths such like '/tmp/hiki//cache'.
In reality, it doesn't cause any trouble because Dir.mkdir
makes proper directory('/tmp/hiki/cache'), but it seems not good.
