### PR TITLE
avoid invalid byte sequence error

### DIFF
--- a/tool/convert.rb
+++ b/tool/convert.rb
@@ -39,7 +39,7 @@ def convert(data_path, database_class, input_encoding, output_encoding, nkf)
   db = database_class.new(config)
   db.pages.each do |page|
     begin
-      old_page = page
+      old_page = page.force_encoding(input_encoding)
       new_page = encode(old_page, input_encoding, output_encoding, nkf)
       print "#{Hiki::Util.escape(old_page)} => #{Hiki::Util.escape(new_page)}"
       old_text = db.load(old_page)


### PR DESCRIPTION
```
ArgumentError: invalid byte sequence in UTF-8
/usr/share/hiki/hiki/util.rb:72:in `gsub'
/usr/share/hiki/hiki/util.rb:72:in `escape'
./tool/convert.rb:45:in `block in convert'
./tool/convert.rb:41:in `each'
./tool/convert.rb:41:in `convert'
./tool/convert.rb:121:in `main'
./tool/convert.rb:126:in `<main>'
```

NG.
と怒られて変換できないエラーを避けるようにしました。
これで正しいのかわかりませんが、動くようになりました。
もしよければ取り込んでください。
