### PR TITLE
attach.rb が無効のときでもファイルアップロードできてしまう不具合の修正

### DIFF
--- a/hiki/attachment.rb
+++ b/hiki/attachment.rb
@@ -26,6 +26,10 @@ module Hiki
     private
 
     def attach_file(request, conf)
+      unless /^attach\.rb$/ =~ conf.options['sp.selected'].to_s then
+        return Hiki::Response.new('plugin "attach.rb" is not enabled',
+                                  404, 'type' => 'text/plain')
+      end
       set_conf(conf)
       params = request.params
       page = params['p'] ? params['p'] : 'FrontPage'


### PR DESCRIPTION
Rack使用時、attach.rb を使用していない時でも、ファイルがアップロードできてしまったので、404を返すようにしてみました。

バグの再現方法: 管理ページで attach.rb を有効にして、適当なページを編集、「参照」でファイルを選択しておき、別ブラウザで管理ページにアクセスして attach.rb を無効にして、元の編集ページで「ファイルの添付」を押す。すると、本来アップロードできないはずが、できてしまう。ファイルの削除も同様にできてしまう。
