### PR TITLE
HikiFarmで既設のwikiを上書きできてしまう

### DIFF
--- a/hiki/farm/manager.rb
+++ b/hiki/farm/manager.rb
@@ -44,7 +44,7 @@ module Hiki
       end
 
       def create_wiki(name)
-        mkdir_p("#{@farm_pub_path}/#{name.untaint}")
+        mkdir("#{@farm_pub_path}/#{name.untaint}")
 
         unless Object.const_defined?(:Rack)
           create_index_cgi(name)
@@ -56,10 +56,10 @@ module Hiki
           f.puts(conf(name, @conf.hiki))
         end
 
-        mkdir_p("#{@conf.data_root}/#{name}")
-        mkdir_p("#{@conf.data_root}/#{name}/text")
-        mkdir_p("#{@conf.data_root}/#{name}/backup")
-        mkdir_p("#{@conf.data_root}/#{name}/cache")
+        mkdir("#{@conf.data_root}/#{name}")
+        mkdir("#{@conf.data_root}/#{name}/text")
+        mkdir("#{@conf.data_root}/#{name}/backup")
+        mkdir("#{@conf.data_root}/#{name}/cache")
         require 'fileutils'
         Dir["#{@conf.default_pages_path}/*"].each do |f|
           f.untaint
@@ -67,6 +67,9 @@ module Hiki
         end
 
         @repos.import(name)
+
+      rescue Errno::EEXIST
+        raise Errno::EEXIST, "that wiki already exists"
       end
 
       def command_key


### PR DESCRIPTION
HikiFarmにて、wikiが既存か否かのチェックがまったく存在しないので、既設のWikiを上書きできてしまいます。上書きされても、ある程度のデータは残りますが、FrontPageその他は確実に上書きされてしまいます。

mkdir_p をすべて mkdir にすることで、race を回避しつつ、既設なら Errno::EEXIST が出てエラーになるようにしています（大元のディレクトリはインストール者が予め作っているのが大前提と考える）。さらに、rescue Errno::EEXIST してから再度 raise しているのは、サーバー内部設定の @conf.data_root がエラーメッセージに含まれて外から安易に見えてしまうのを防ぐためです。
