### PR TITLE
Rack版hikifarmのデフォルトドキュメントの場所指定は @default_pages_path に変更になっていた

### DIFF
--- a/misc/hikifarm/hikifarm_conf.rb
+++ b/misc/hikifarm/hikifarm_conf.rb
@@ -9,7 +9,7 @@
 @hikifarm_description = 'HogeHogeHikiFarm'
 
 # 作成したWikiサイトにあらかじめ入れたいドキュメントがあるディレクトリ
-@default_pages = "#{hiki}/data/text"
+@default_pages_path = "#{@hiki}/data/text"
 
 # データを入れるディレクトリ
 # この下に各Wiki名のディレクトリが掘られる


### PR DESCRIPTION
CGI版hikifarm時代は、設定ファイルの変数名が default_pages （ローカル変数）で、クラスのインスタンス変数名が @default_pages_path という、違う名前を使っている状態でした。Rack対応時に、Hiki::Farm::Configのインスタンス変数に直接読み込むよう変更された際に、CGI版でそんなややこしい事をしていると気が付かず、取り残されたのだと思います。また、hiki --> @hiki の修正も必要でした。
