### PR TITLE
fix typo in head?

### DIFF
--- a/hiki/request.rb
+++ b/hiki/request.rb
@@ -54,7 +54,7 @@ module Hiki
       end
 
       def head?
-        request_method = 'HEAD'
+        request_method == 'HEAD'
       end
 
       def post?


### PR DESCRIPTION
hiki/request.rb の head? の中で = となっていたところを == に置き換えました。